### PR TITLE
Add GHCR Docker publish workflow and server Dockerfile

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,52 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: rad-ai
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./server
+          file: ./server/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:20-alpine AS runtime
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY --from=build /app/dist ./dist
+
+EXPOSE 3000
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
### Motivation
- Provide a CI workflow to build and publish a Docker image to GHCR on pushes to `main` or when tags are pushed.
- Ensure the TypeScript server is containerized with a reproducible multi-stage build that compiles sources and produces a lean runtime image.
- Automate tagging of images (e.g., `ghcr.io/<owner>/rad-ai:latest` and `:sha`) and push to the registry using the repo token.

### Description
- Add `.github/workflows/docker-publish.yml` which triggers on `push` to `main` and on tags, logs in to `ghcr.io` using `GITHUB_TOKEN`, and uses `docker/build-push-action` with `docker/metadata-action` to tag and push the image.
- Workflow sets `REGISTRY=ghcr.io` and `IMAGE_NAME=rad-ai` and grants `packages: write` permission so GHCR pushes succeed.
- Add `server/Dockerfile` multi-stage build that installs dependencies, runs `npm run build` to compile TypeScript, and creates a production runtime image that runs `node dist/index.js` and exposes port `3000`.
- The build step uses `npm ci`, the runtime uses `npm ci --omit=dev`, and the `docker/build-push-action` is configured to build from `./server` with `./server/Dockerfile`.

### Testing
- No automated tests were executed for these changes because they are workflow and Dockerfile additions only.
- The workflow was validated syntactically by adding the file to the repository and committing it, but the GitHub Actions run has not been executed here.
- The `server/Dockerfile` was created to match the existing `server` package scripts (`build` and `start`) and is ready for workflow runs.
- No CI failures reported locally since no actions were run against GHCR in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958b7c67e74832e8898859dd9b762e7)